### PR TITLE
WIP: check if xen was run by SKINIT

### DIFF
--- a/xen/arch/x86/alternative.c
+++ b/xen/arch/x86/alternative.c
@@ -359,6 +359,7 @@ static void __init _alternative_instructions(bool force)
 {
     unsigned int i;
     nmi_callback_t *saved_nmi_callback;
+    uint64_t msr_content;
 
     /*
      * Don't stop machine check exceptions while patching.
@@ -381,6 +382,15 @@ static void __init _alternative_instructions(bool force)
      * even an NMI ahead of our explicit self-NMI.
      */
     saved_nmi_callback = set_nmi_callback(nmi_apply_alternatives);
+
+    /* Check is R_INIT bit set to determinate if xen was run by SKINIT */
+    rdmsrl(MSR_K8_VM_CR, msr_content);
+    if(msr_content & K8_VMCR_R_INIT)
+    {
+        printk(KERN_INFO "K8_VMCR_R_INIT is set \n");
+        msr_content &= ~K8_VMCR_R_INIT;
+        wrmsrl(MSR_K8_VM_CR, msr_content);
+    }
 
     /* Send ourselves an NMI to trigger the callback. */
     self_nmi();

--- a/xen/include/asm-x86/msr-index.h
+++ b/xen/include/asm-x86/msr-index.h
@@ -257,6 +257,8 @@
 /* MSR_K8_VM_CR bits: */
 #define _K8_VMCR_SVME_DISABLE		4
 #define K8_VMCR_SVME_DISABLE		(1 << _K8_VMCR_SVME_DISABLE)
+#define _K8_VMCR_R_INIT          1
+#define K8_VMCR_R_INIT           (1 << _K8_VMCR_R_INIT)
 
 /* AMD64 MSRs */
 #define MSR_AMD64_NB_CFG		0xc001001f


### PR DESCRIPTION
Flag can be set in place of `printk`