### PR TITLE
xen/arch/x86/boot/head.S: Re-enable SMI in sl_stub

### DIFF
--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -401,6 +401,15 @@ cs32_switch:
 
 sl_stub_entry:
 
+        /*
+	 * Enable SMI with GETSEC[SMCTRL] which were disabled by SENTER.
+	 */
+        pushl    %ebx
+        xorl     %ebx,%ebx
+        movl     $7,%eax
+	getsec
+        popl     %ebx
+
         jmp __start
 
 #ifdef CONFIG_PVH_GUEST


### PR DESCRIPTION
Signed-off-by: Kacper Stojek <kacper.stojek@3mdeb.com>