### PR TITLE
arch/x82/boot/txt_early: add early TXT tests and restore MBI pointer

### DIFF
--- a/docs/hypervisor-guide/x86/how-xen-boots.rst
+++ b/docs/hypervisor-guide/x86/how-xen-boots.rst
@@ -55,6 +55,11 @@ If ``CONFIG_PVH_GUEST`` was selected at build time, an Elf note is included
 which indicates the ability to use the PVH boot protocol, and registers
 ``__pvh_start`` as the entrypoint, entered in 32bit mode.
 
+MLE header is used with Intel TXT, together with MB2 headers. Entrypoint is
+different, but it is used just to differentiate from other entries by moving
+a magic number to EAX. Execution environment is similar to that of Multiboot
+and code falls through to ``start``.
+
 
 xen.gz
 ~~~~~~

--- a/xen/arch/x86/boot/Makefile
+++ b/xen/arch/x86/boot/Makefile
@@ -1,6 +1,6 @@
 obj-bin-y += head.o
 
-head-bin-objs := cmdline.o reloc.o
+head-bin-objs := cmdline.o reloc.o txt_early.o
 
 nocov-y   += $(head-bin-objs)
 noubsan-y += $(head-bin-objs)

--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -122,7 +122,7 @@ mle_header:
         .long	0x42b651cb  /* UUID3 */
         .long   0x00000034  /* MLE header size */
         .long	0x00020002  /* MLE version 2.2 */
-        .long   sym_offs(sl_stub_entry)  /* Linear entry point of MLE (virt. address) */
+        .long   (sl_stub_entry - start)  /* Linear entry point of MLE (SINIT virt. address) */
         .long   0x00000000  /* First valid page of MLE */
         .long   0x00000000  /* Offset within binary of first byte of MLE */
         .long   0x00000000  /* Offset within binary of last byte + 1 of MLE */

--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -3,6 +3,7 @@
 #include <public/xen.h>
 #include <asm/asm_defns.h>
 #include <asm/fixmap.h>
+#include <asm/intel_txt.h>
 #include <asm/page.h>
 #include <asm/processor.h>
 #include <asm/msr-index.h>
@@ -397,19 +398,6 @@ cs32_switch:
         /* Jump to earlier loaded address. */
         jmp     *%edi
 
-
-sl_stub_entry:
-
-        /* Calculate the load base address. */
-        call    1f
-1:      pop     %esi
-        sub     $sym_offs(1b), %esi
-
-        /* Save information that TrenchBoot slaunch was used. */
-        movl $1, sym_esi(sl_status)
-
-        jmp __start
-
 #ifdef CONFIG_PVH_GUEST
 ELFNOTE(Xen, XEN_ELFNOTE_PHYS32_ENTRY, .long sym_offs(__pvh_start))
 
@@ -457,6 +445,11 @@ __pvh_start:
 
 #endif /* CONFIG_PVH_GUEST */
 
+sl_stub_entry:
+        movl    $SLAUNCH_BOOTLOADER_MAGIC,%eax
+
+        /* Fall through to Multiboot entry point. */
+
 __start:
         cld
         cli
@@ -485,6 +478,10 @@ __start:
         /* Bootloaders may set multiboot{1,2}.mem_lower to a nonzero value. */
         xor     %edx,%edx
 
+        /* Check for TrenchBoot slaunch bootloader. */
+        cmp     $SLAUNCH_BOOTLOADER_MAGIC,%eax
+        je      .Lslaunch_proto
+
         /* Check for Multiboot2 bootloader. */
         cmp     $MULTIBOOT2_BOOTLOADER_MAGIC,%eax
         je      .Lmultiboot2_proto
@@ -499,6 +496,21 @@ __start:
         /* Not available? BDA value will be fine. */
         cmovnz  MB_mem_lower(%ebx),%edx
         jmp     trampoline_bios_setup
+
+.Lslaunch_proto:
+        /* Save information that TrenchBoot slaunch was used. */
+        movl $1, sym_esi(sl_status)
+
+        /* Pass load base address to txt_early_tests(). */
+        push    %esi
+        call    txt_early_tests
+
+        /*
+         * txt_early_tests() returns MBI address, move it to EBX, move magic
+         * number expected by Multiboot 2 to EAX and fall through.
+         */
+        movl    %eax,%ebx
+        movl    $MULTIBOOT2_BOOTLOADER_MAGIC,%eax
 
 .Lmultiboot2_proto:
         /* Skip Multiboot2 information fixed part. */
@@ -820,6 +832,10 @@ cmdline_parse_early:
         ALIGN
 reloc:
         .incbin "reloc.bin"
+
+        ALIGN
+txt_early_tests:
+        .incbin "txt_early.bin"
 
 ENTRY(trampoline_start)
 #include "trampoline.S"

--- a/xen/arch/x86/boot/head.S
+++ b/xen/arch/x86/boot/head.S
@@ -445,6 +445,26 @@ __pvh_start:
 
 #endif /* CONFIG_PVH_GUEST */
 
+        /*
+         * Entry point for TrenchBoot Secure Launch on Intel TXT platforms.
+         *
+         * CPU is in 32b protected mode with paging disabled. On entry:
+         * - %ebx = %ebp = SINIT physical base address
+         * - %edx = SENTER control flags
+         * - stack pointer is undefined
+         * - CS is flat 4GB code segment
+         * - DS, ES and SS are flat 4GB data segments
+         *
+         * Additional restrictions:
+         * - some MSRs are partially cleared, among them IA32_MISC_ENABLE, so
+         *   some capabilities might be reported as disabled even if they are
+         *   supported by CPU
+         * - interrupts (including NMIs and SMIs) are disabled and must be
+         *   enabled later
+         * - trying to enter real mode results in reset
+         * - APs must be brought up by MONITOR or GETSEC[WAKEUP], depending on
+         *   which is supported by a given SINIT ACM
+         */
 sl_stub_entry:
         movl    $SLAUNCH_BOOTLOADER_MAGIC,%eax
 

--- a/xen/arch/x86/boot/txt_early.c
+++ b/xen/arch/x86/boot/txt_early.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 3mdeb Sp. z o.o. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This entry point is entered from xen/arch/x86/boot/head.S with Xen base at
+ * 0x4(%esp). A pointer to MBI is returned in %eax.
+ */
+asm (
+    "    .text                         \n"
+    "    .globl _start                 \n"
+    "_start:                           \n"
+    "    jmp  txt_early_tests          \n"
+    );
+
+#include "defs.h"
+#include "../include/asm/intel_txt.h"
+
+static void verify_os_mle_struct(struct txt_os_mle_data *os_mle,
+                                 struct txt_os_sinit_data *os_sinit,
+                                 uint32_t mle_base)
+{
+    /* Verify the value of the low PMR base. It should always be 0. */
+    if (os_sinit->vtd_pmr_lo_base != 0)
+        txt_reset(SL_ERROR_LO_PMR_BASE);
+
+    /* Check for size overflow (should be caught by SINIT during page walk). */
+    if (mle_base + os_sinit->mle_size < mle_base)
+        txt_reset(SL_ERROR_INTEGER_OVERFLOW);
+
+    /* TODO: AP wake block size and PMR low size, if needed */
+}
+
+uint32_t __stdcall txt_early_tests(uint32_t mle_base)
+{
+    void *txt_heap;
+    struct txt_os_mle_data *os_mle;
+    struct txt_os_sinit_data *os_sinit;
+
+    /* Clear the TXT error registers for a clean start of day */
+    write_txt_reg(TXTCR_ERRORCODE, 0);
+
+    txt_heap = _p(read_txt_reg(TXTCR_HEAP_BASE));
+
+    if (txt_os_mle_data_size(txt_heap) < sizeof(*os_mle) ||
+        txt_os_sinit_data_size(txt_heap) < sizeof(*os_sinit))
+        txt_reset(SL_ERROR_GENERIC);
+
+    os_mle = txt_os_mle_data_start(txt_heap);
+    os_sinit = txt_os_sinit_data_start(txt_heap);
+
+    verify_os_mle_struct(os_mle, os_sinit, mle_base);
+
+    /* TODO: store mle_base in OS-MLE scratch for APs? */
+
+    return os_mle->boot_params_addr;
+}

--- a/xen/arch/x86/include/asm/intel_txt.h
+++ b/xen/arch/x86/include/asm/intel_txt.h
@@ -2,17 +2,271 @@
  * TXT configuration registers (offsets from TXT_{PUB, PRIV}_CONFIG_REGS_BASE)
  */
 
-#define TXT_PUB_CONFIG_REGS_BASE       0xfed30000
-#define TXT_PRIV_CONFIG_REGS_BASE      0xfed20000
+#define TXT_PUB_CONFIG_REGS_BASE	0xfed30000
+#define TXT_PRIV_CONFIG_REGS_BASE	0xfed20000
 
-/* # pages for each config regs space - used by fixmap */
-#define NR_TXT_CONFIG_PAGES     ((TXT_PUB_CONFIG_REGS_BASE -                \
-                                  TXT_PRIV_CONFIG_REGS_BASE) >> PAGE_SHIFT)
+#define NR_TXT_CONFIG_PAGES	((TXT_PUB_CONFIG_REGS_BASE - \
+				  TXT_PRIV_CONFIG_REGS_BASE) >> PAGE_SHIFT)
 
-/* offsets from pub/priv config space */
-#define TXTCR_SINIT_BASE            0x0270
-#define TXTCR_SINIT_SIZE            0x0278
-#define TXTCR_HEAP_BASE             0x0300
-#define TXTCR_HEAP_SIZE             0x0308
+#define TXTCR_STS			0x0000
+#define TXTCR_ESTS			0x0008
+#define TXTCR_ERRORCODE			0x0030
+#define TXTCR_CMD_RESET			0x0038
+#define TXTCR_CMD_CLOSE_PRIVATE		0x0048
+#define TXTCR_DIDVID			0x0110
+#define TXTCR_VER_EMIF			0x0200
+#define TXTCR_CMD_UNLOCK_MEM_CONFIG	0x0218
+#define TXTCR_SINIT_BASE		0x0270
+#define TXTCR_SINIT_SIZE		0x0278
+#define TXTCR_MLE_JOIN			0x0290
+#define TXTCR_HEAP_BASE			0x0300
+#define TXTCR_HEAP_SIZE			0x0308
+#define TXTCR_SCRATCHPAD		0x0378
+#define TXTCR_CMD_OPEN_LOCALITY1	0x0380
+#define TXTCR_CMD_CLOSE_LOCALITY1	0x0388
+#define TXTCR_CMD_OPEN_LOCALITY2	0x0390
+#define TXTCR_CMD_CLOSE_LOCALITY2	0x0398
+#define TXTCR_CMD_SECRETS		0x08e0
+#define TXTCR_CMD_NO_SECRETS		0x08e8
+#define TXTCR_E2STS			0x08f0
+
+/*
+ * Secure Launch Defined Error Codes used in MLE-initiated TXT resets.
+ *
+ * TXT Specification
+ * Appendix I ACM Error Codes
+ */
+#define SL_ERROR_GENERIC		0xc0008001
+#define SL_ERROR_TPM_INIT		0xc0008002
+#define SL_ERROR_TPM_INVALID_LOG20	0xc0008003
+#define SL_ERROR_TPM_LOGGING_FAILED	0xc0008004
+#define SL_ERROR_REGION_STRADDLE_4GB	0xc0008005
+#define SL_ERROR_TPM_EXTEND		0xc0008006
+#define SL_ERROR_MTRR_INV_VCNT		0xc0008007
+#define SL_ERROR_MTRR_INV_DEF_TYPE	0xc0008008
+#define SL_ERROR_MTRR_INV_BASE		0xc0008009
+#define SL_ERROR_MTRR_INV_MASK		0xc000800a
+#define SL_ERROR_MSR_INV_MISC_EN	0xc000800b
+#define SL_ERROR_INV_AP_INTERRUPT	0xc000800c
+#define SL_ERROR_INTEGER_OVERFLOW	0xc000800d
+#define SL_ERROR_HEAP_WALK		0xc000800e
+#define SL_ERROR_HEAP_MAP		0xc000800f
+#define SL_ERROR_REGION_ABOVE_4GB	0xc0008010
+#define SL_ERROR_HEAP_INVALID_DMAR	0xc0008011
+#define SL_ERROR_HEAP_DMAR_SIZE		0xc0008012
+#define SL_ERROR_HEAP_DMAR_MAP		0xc0008013
+#define SL_ERROR_HI_PMR_BASE		0xc0008014
+#define SL_ERROR_HI_PMR_SIZE		0xc0008015
+#define SL_ERROR_LO_PMR_BASE		0xc0008016
+#define SL_ERROR_LO_PMR_MLE		0xc0008017
+#define SL_ERROR_INITRD_TOO_BIG		0xc0008018
+#define SL_ERROR_HEAP_ZERO_OFFSET	0xc0008019
+#define SL_ERROR_WAKE_BLOCK_TOO_SMALL	0xc000801a
+#define SL_ERROR_MLE_BUFFER_OVERLAP	0xc000801b
+#define SL_ERROR_BUFFER_BEYOND_PMR	0xc000801c
+#define SL_ERROR_OS_SINIT_BAD_VERSION	0xc000801d
+#define SL_ERROR_EVENTLOG_MAP		0xc000801e
+#define SL_ERROR_TPM_NUMBER_ALGS	0xc000801f
+#define SL_ERROR_TPM_UNKNOWN_DIGEST	0xc0008020
+#define SL_ERROR_TPM_INVALID_EVENT	0xc0008021
+
+#define TXT_OS_MLE_MAX_VARIABLE_MTRRS	32
+
+#define SLAUNCH_BOOTLOADER_MAGIC	0x4c534254
+
+#ifndef __ASSEMBLY__
+
+/*
+ * Always use private space as some of registers are either read-only or not
+ * present in public space.
+ */
+static inline volatile uint32_t read_txt_reg(int reg_no)
+{
+	volatile uint32_t *reg = _p(TXT_PRIV_CONFIG_REGS_BASE + reg_no);
+	return *reg;
+}
+
+static inline void write_txt_reg(int reg_no, uint32_t val)
+{
+	volatile uint32_t *reg = _p(TXT_PRIV_CONFIG_REGS_BASE + reg_no);
+	*reg = val;
+	/* This serves as TXT register barrier */
+	(void)read_txt_reg(TXTCR_ESTS);
+}
+
+static inline void txt_reset(uint32_t error)
+{
+	write_txt_reg(TXTCR_ERRORCODE, error);
+	write_txt_reg(TXTCR_CMD_NO_SECRETS, 1);
+	write_txt_reg(TXTCR_CMD_UNLOCK_MEM_CONFIG, 1);
+	write_txt_reg(TXTCR_CMD_RESET, 1);
+	while (1);
+}
+
+/*
+ * Secure Launch defined MTRR saving structures
+ */
+struct txt_mtrr_pair {
+	uint64_t mtrr_physbase;
+	uint64_t mtrr_physmask;
+} __packed;
+
+struct txt_mtrr_state {
+	uint64_t default_mem_type;
+	uint64_t mtrr_vcnt;
+	struct txt_mtrr_pair mtrr_pair[TXT_OS_MLE_MAX_VARIABLE_MTRRS];
+} __packed;
+
+/*
+ * Secure Launch defined OS/MLE TXT Heap table
+ */
+struct txt_os_mle_data {
+	uint32_t version;
+	uint32_t boot_params_addr;
+	uint64_t saved_misc_enable_msr;
+	struct txt_mtrr_state saved_bsp_mtrrs;
+	uint32_t ap_wake_block;
+	uint32_t ap_wake_block_size;
+	uint64_t evtlog_addr;
+	uint32_t evtlog_size;
+	uint8_t mle_scratch[64];
+} __packed;
+
+/*
+ * TXT specification defined BIOS data TXT Heap table
+ */
+struct txt_bios_data {
+	uint32_t version; /* Currently 5 for TPM 1.2 and 6 for TPM 2.0 */
+	uint32_t bios_sinit_size;
+	uint64_t reserved1;
+	uint64_t reserved2;
+	uint32_t num_logical_procs;
+	/* Versions >= 3 && < 5 */
+	uint32_t sinit_flags;
+	/* Versions >= 5 with updates in version 6 */
+	uint32_t mle_flags;
+	/* Versions >= 4 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * TXT specification defined OS/SINIT TXT Heap table
+ */
+struct txt_os_sinit_data {
+	uint32_t version;	/* Currently 6 for TPM 1.2 and 7 for TPM 2.0 */
+	uint32_t flags;		/* Reserved in version 6 */
+	uint64_t mle_ptab;
+	uint64_t mle_size;
+	uint64_t mle_hdr_base;
+	uint64_t vtd_pmr_lo_base;
+	uint64_t vtd_pmr_lo_size;
+	uint64_t vtd_pmr_hi_base;
+	uint64_t vtd_pmr_hi_size;
+	uint64_t lcp_po_base;
+	uint64_t lcp_po_size;
+	uint32_t capabilities;
+	/* Version = 5 */
+	uint64_t efi_rsdt_ptr;	/* RSD*P* in versions >= 6 */
+	/* Versions >= 6 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * TXT specification defined SINIT/MLE TXT Heap table
+ */
+struct txt_sinit_mle_data {
+	uint32_t version;	/* Current values are 6 through 9 */
+	/* Versions <= 8, fields until lcp_policy_control must be 0 for >= 9 */
+	uint8_t bios_acm_id[20];
+	uint32_t edx_senter_flags;
+	uint64_t mseg_valid;
+	uint8_t sinit_hash[20];
+	uint8_t mle_hash[20];
+	uint8_t stm_hash[20];
+	uint8_t lcp_policy_hash[20];
+	uint32_t lcp_policy_control;
+	/* Versions >= 7 */
+	uint32_t rlp_wakeup_addr;
+	uint32_t reserved;
+	uint32_t num_of_sinit_mdrs;
+	uint32_t sinit_mdrs_table_offset;
+	uint32_t sinit_vtd_dmar_table_size;
+	uint32_t sinit_vtd_dmar_table_offset;
+	/* Versions >= 8 */
+	uint32_t processor_scrtm_status;
+	/* Versions >= 9 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * Functions to extract data from the Intel TXT Heap Memory. The layout
+ * of the heap is as follows:
+ *  +---------------------------------+
+ *  | Size Bios Data table (uint64_t) |
+ *  +---------------------------------+
+ *  | Bios Data table                 |
+ *  +---------------------------------+
+ *  | Size OS MLE table (uint64_t)    |
+ *  +---------------------------------+
+ *  | OS MLE table                    |
+ *  +-------------------------------- +
+ *  | Size OS SINIT table (uint64_t)  |
+ *  +---------------------------------+
+ *  | OS SINIT table                  |
+ *  +---------------------------------+
+ *  | Size SINIT MLE table (uint64_t) |
+ *  +---------------------------------+
+ *  | SINIT MLE table                 |
+ *  +---------------------------------+
+ *
+ *  NOTE: the table size fields include the 8 byte size field itself.
+ */
+static inline uint64_t txt_bios_data_size(void *heap)
+{
+	return *((uint64_t *)heap);
+}
+
+static inline void *txt_bios_data_start(void *heap)
+{
+	return heap + sizeof(uint64_t);
+}
+
+static inline uint64_t txt_os_mle_data_size(void *heap)
+{
+	return *((uint64_t *)(heap + txt_bios_data_size(heap)));
+}
+
+static inline void *txt_os_mle_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) + sizeof(uint64_t);
+}
+
+static inline uint64_t txt_os_sinit_data_size(void *heap)
+{
+	return *((uint64_t *)(heap + txt_bios_data_size(heap) +
+			txt_os_mle_data_size(heap)));
+}
+
+static inline void *txt_os_sinit_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) +
+		txt_os_mle_data_size(heap) + sizeof(uint64_t);
+}
+
+static inline uint64_t txt_sinit_mle_data_size(void *heap)
+{
+	return *((uint64_t *)(heap + txt_bios_data_size(heap) +
+			txt_os_mle_data_size(heap) +
+			txt_os_sinit_data_size(heap)));
+}
+
+static inline void *txt_sinit_mle_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) +
+		txt_os_mle_data_size(heap) +
+		txt_sinit_mle_data_size(heap) + sizeof(uint64_t);
+}
 
 void protect_txt_mem_regions(void);
+
+#endif /* __ASSEMBLY__ */

--- a/xen/arch/x86/intel_txt.c
+++ b/xen/arch/x86/intel_txt.c
@@ -2,7 +2,6 @@
 #include <asm/e820.h>
 #include <xen/string.h>
 #include <asm/page.h>
-
 #include <asm/intel_txt.h>
 
 void protect_txt_mem_regions(void)
@@ -10,23 +9,43 @@ void protect_txt_mem_regions(void)
     uint64_t txt_heap_base, txt_heap_size;
     uint64_t sinit_base, sinit_size;
     int rc;
+    const unsigned int l2e_off = l2_linear_offset(TXT_PUB_CONFIG_REGS_BASE);
+    l2_pgentry_t *l2e = &l2_bootmap[l2e_off];
+
+    if ( l2e_get_flags(*l2e) & _PAGE_PRESENT )
+        panic("Memory for TXT register space already mapped\n");
+
+    /* Create new L2 page table entry covering TXT register space. */
+    l2e->l2 = (TXT_PUB_CONFIG_REGS_BASE & ~((1ULL << L2_PAGETABLE_SHIFT) - 1))
+              | __PAGE_HYPERVISOR_UC | _PAGE_PSE;
+    asm volatile ( "invlpg %0" : :
+                    "m" (*(const char *)TXT_PUB_CONFIG_REGS_BASE)
+                    : "memory" );
 
     txt_heap_base = txt_heap_size = sinit_base = sinit_size = 0;
     /* TXT Heap */
-    memcpy(maddr_to_virt(TXT_PUB_CONFIG_REGS_BASE + TXTCR_HEAP_BASE),
+    memcpy((void *)(TXT_PUB_CONFIG_REGS_BASE + TXTCR_HEAP_BASE),
            &txt_heap_base , sizeof(txt_heap_base));
-    memcpy(maddr_to_virt(TXT_PUB_CONFIG_REGS_BASE + TXTCR_HEAP_SIZE),
+    memcpy((void *)(TXT_PUB_CONFIG_REGS_BASE + TXTCR_HEAP_SIZE),
            &txt_heap_size , sizeof(txt_heap_size));
     /* SINIT */
-    memcpy(maddr_to_virt(TXT_PUB_CONFIG_REGS_BASE + TXTCR_SINIT_BASE),
+    memcpy((void *)(TXT_PUB_CONFIG_REGS_BASE + TXTCR_SINIT_BASE),
            &sinit_base , sizeof(sinit_base));
-    memcpy(maddr_to_virt(TXT_PUB_CONFIG_REGS_BASE + TXTCR_SINIT_SIZE),
+    memcpy((void *)(TXT_PUB_CONFIG_REGS_BASE + TXTCR_SINIT_SIZE),
            &sinit_size , sizeof(sinit_size));
+
+    /* Remove mapping of TXT register space. */
+    l2e->l2 = 0;
+    asm volatile ( "invlpg %0" : :
+                    "m" (*(const char *)TXT_PUB_CONFIG_REGS_BASE)
+                    : "memory" );
 
     /* TXT Heap */
     if ( txt_heap_base == 0 )
         return;
 
+    printk("SLAUNCH: reserving TXT heap (%#lx - %#lx)\n", txt_heap_base,
+           txt_heap_base + txt_heap_size);
     rc = e820_change_range_type(&e820, txt_heap_base,
                                 txt_heap_base + txt_heap_size,
                                 E820_RESERVED, E820_UNUSABLE);
@@ -36,6 +55,9 @@ void protect_txt_mem_regions(void)
     /* SINIT */
     if ( sinit_base == 0 )
         return;
+
+    printk("SLAUNCH: reserving SINIT memory (%#lx - %#lx)\n", sinit_base,
+           sinit_base + sinit_size);
     rc = e820_change_range_type(&e820, sinit_base,
                                 sinit_base + sinit_size,
                                 E820_RESERVED, E820_UNUSABLE);

--- a/xen/arch/x86/setup.c
+++ b/xen/arch/x86/setup.c
@@ -1146,9 +1146,6 @@ void __init noreturn __start_xen(unsigned long mbi_p)
     /* Sanitise the raw E820 map to produce a final clean version. */
     max_page = raw_max_page = init_e820(memmap_type, &e820_raw);
 
-    if ( sl_status )
-        protect_txt_mem_regions();
-
     if ( !efi_enabled(EFI_BOOT) && e820_raw.nr_map >= 1 )
     {
         /*
@@ -1163,6 +1160,10 @@ void __init noreturn __start_xen(unsigned long mbi_p)
 
     /* Create a temporary copy of the E820 map. */
     memcpy(&boot_e820, &e820, sizeof(e820));
+
+    /* Reserve TXT heap and SINIT for Secure Launch path. */
+    if ( sl_status )
+        protect_txt_mem_regions();
 
     /* Early kexec reservation (explicit static start address). */
     nr_pages = 0;


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>